### PR TITLE
fix(ci): upgrade deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -47,9 +47,9 @@ jobs:
           pytest tests/ --cov=src --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
@@ -123,7 +123,7 @@ jobs:
           docker run --rm asai-x-bot:latest python -c "import src.main; print('Import test successful')"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: htmlcov/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 浅井恋乃未 X Bot
 
-[![CI](https://github.com/iwakiaoiyou/asai-x-bot/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/iwakiaoiyou/asai-x-bot/actions/workflows/ci.yml)
+[![CI](https://github.com/AobaIwaki123/asai-x-bot/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/AobaIwaki123/asai-x-bot/actions/workflows/ci.yml)
 
 ## 概要
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -70,9 +70,9 @@ pytest tests/test_config.py::TestConfig::test_validate_env_vars_all_present -v
 
 ### リント
 ```bash
-# flake8でのコード品質チェック
+# ruffでのコード品質チェック
 make lint
-flake8 src tests
+ruff check src/ tests/
 
 # 型チェック
 make type-check
@@ -83,13 +83,13 @@ mypy src --ignore-missing-imports
 ```bash
 # コードフォーマット実行
 make format
-black src/ tests/
-isort src/ tests/
+ruff format src/ tests/
+ruff check --fix src/ tests/
 
 # フォーマットチェック（変更なし）
 make format-check
-black --check src/ tests/
-isort --check-only src/ tests/
+ruff format --check src/ tests/
+ruff check src/ tests/
 ```
 
 ### セキュリティチェック
@@ -105,12 +105,12 @@ safety check
 ### ワークフロー
 
 #### メインCI（`.github/workflows/ci.yml`）
-- **Python 3.9, 3.10, 3.11** でのマトリックステスト
-- リント（flake8）
+- **Python 3.12** でのテスト実行
+- リント（ruff）
 - 型チェック（mypy）
 - テスト実行（pytest + coverage）
 - セキュリティチェック（bandit, safety）
-- コードフォーマットチェック（black, isort）
+- コードフォーマットチェック（ruff）
 - Docker イメージビルドテスト
 - Codecov連携
 


### PR DESCRIPTION
## 📋 変更内容

GitHub Actionsで使用している非推奨のアクションを最新バージョンに更新しました。

### 🔧 修正内容

- `actions/upload-artifact`: v3 → v4 に更新
- `actions/cache`: v3 → v4 に更新  
- `codecov/codecov-action`: v3 → v4 に更新

### 🚨 解決した問題

`actions/upload-artifact@v3` の非推奨エラーを解決:
```
Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3
```

### ⚙️ API変更への対応

- codecov-action v4での仕様変更に対応
  - パラメータ名を `file` → `files` に変更

### ✅ テスト

- [ ] CIパイプラインが正常に動作することを確認
- [ ] アーティファクトのアップロードが正常に動作することを確認
- [ ] Codecovへのカバレッジレポート送信が正常に動作することを確認

## 📚 参考リンク

- [GitHub Actions: Deprecation notice for v3 of the artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)