### PR TITLE
feat: Send tweet URLs directly instead of rich embeds

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ X APIからツイートを取得してDiscordに転送するボット
 """
 
 from .config import validate_env_vars
-from .discord_client import discord_post, to_embed
+from .discord_client import discord_post, get_tweet_url
 from .main import fetch_and_forward, main
 from .utils import build_index, load_since_id, save_since_id
 from .x_api_client import fetch_tweets
@@ -20,5 +20,5 @@ __all__ = [
     "build_index",
     "fetch_tweets",
     "discord_post",
-    "to_embed",
+    "get_tweet_url",
 ]

--- a/src/discord_client.py
+++ b/src/discord_client.py
@@ -1,4 +1,3 @@
-import html
 import logging
 from typing import cast
 
@@ -26,40 +25,9 @@ def discord_post(content=None, embed=None):
         raise
 
 
-def to_embed(tweet, users_idx, media_idx):
+def get_tweet_url(tweet, users_idx):
+    """ツイートのURLを生成する"""
     author = users_idx.get(tweet["author_id"], {})
     t_id = tweet["id"]
     username = author.get("username", "unknown")
-    screen_url = f"https://x.com/{username}/status/{t_id}"
-
-    # 画像があれば最初の1枚を埋め込み
-    image_url = None
-    if "attachments" in tweet and "media_keys" in tweet["attachments"]:
-        for mk in tweet["attachments"]["media_keys"]:
-            m = media_idx.get(mk)
-            if m and m.get("type") == "photo":
-                image_url = m.get("url") or m.get("preview_image_url")
-                break
-
-    # Embed
-    title = f"@{username}"
-    description = html.unescape(tweet.get("text", ""))[:4000]  # Discord制限対策
-    author_name = author.get("name", username)
-    author_icon = author.get("profile_image_url")
-
-    embed = {
-        "title": title,
-        "url": screen_url,
-        "description": description,
-        "author": {
-            "name": author_name,
-            "url": f"https://x.com/{username}",
-            "icon_url": author_icon,
-        },
-        "footer": {
-            "text": f"likes: {tweet['public_metrics']['like_count']}  rt: {tweet['public_metrics']['retweet_count']}"  # noqa: E501
-        },
-    }
-    if image_url:
-        embed["image"] = {"url": image_url}
-    return embed
+    return f"https://x.com/{username}/status/{t_id}"

--- a/tests/test_discord_client.py
+++ b/tests/test_discord_client.py
@@ -8,7 +8,7 @@ import responses
 
 sys.path.append("src")
 
-from src.discord_client import discord_post, to_embed
+from src.discord_client import discord_post, get_tweet_url
 
 
 class TestDiscordClient:
@@ -117,152 +117,34 @@ class TestDiscordClient:
             with pytest.raises(ConnectionError):
                 discord_post(content="Test message")
 
-    def test_to_embed_basic_tweet(self):
-        """基本的なツイートの埋め込み変換テスト"""
+    def test_get_tweet_url_basic(self):
+        """基本的なツイートURLの生成テスト"""
         tweet = {
             "id": "123456789",
             "author_id": "user1",
-            "text": "This is a test tweet",
-            "public_metrics": {
-                "like_count": 10,
-                "retweet_count": 5,
-            },
         }
 
         users_idx = {
             "user1": {
                 "username": "testuser",
-                "name": "Test User",
-                "profile_image_url": "https://example.com/avatar.jpg",
             }
         }
 
-        media_idx: dict[str, dict] = {}
-
-        result = to_embed(tweet, users_idx, media_idx)
-
-        expected = {
-            "title": "@testuser",
-            "url": "https://x.com/testuser/status/123456789",
-            "description": "This is a test tweet",
-            "author": {
-                "name": "Test User",
-                "url": "https://x.com/testuser",
-                "icon_url": "https://example.com/avatar.jpg",
-            },
-            "footer": {"text": "likes: 10  rt: 5"},
-        }
+        result = get_tweet_url(tweet, users_idx)
+        expected = "https://x.com/testuser/status/123456789"
 
         assert result == expected
 
-    def test_to_embed_with_image(self):
-        """画像付きツイートの埋め込み変換テスト"""
-        tweet = {
-            "id": "123456789",
-            "author_id": "user1",
-            "text": "Tweet with image",
-            "public_metrics": {
-                "like_count": 20,
-                "retweet_count": 8,
-            },
-            "attachments": {"media_keys": ["media1", "media2"]},
-        }
-
-        users_idx = {
-            "user1": {
-                "username": "testuser",
-                "name": "Test User",
-            }
-        }
-
-        media_idx = {
-            "media1": {
-                "type": "photo",
-                "url": "https://example.com/image1.jpg",
-            },
-            "media2": {
-                "type": "video",
-                "preview_image_url": "https://example.com/video_thumb.jpg",
-            },
-        }
-
-        result = to_embed(tweet, users_idx, media_idx)
-
-        # 最初の画像が埋め込まれることを確認
-        assert "image" in result
-        assert result["image"]["url"] == "https://example.com/image1.jpg"
-
-    def test_to_embed_unknown_user(self):
-        """不明なユーザーのツイート埋め込み変換テスト"""
+    def test_get_tweet_url_unknown_user(self):
+        """不明なユーザーのツイートURL生成テスト"""
         tweet = {
             "id": "123456789",
             "author_id": "unknown_user",
-            "text": "Tweet from unknown user",
-            "public_metrics": {
-                "like_count": 0,
-                "retweet_count": 0,
-            },
         }
 
         users_idx: dict[str, dict] = {}
-        media_idx: dict[str, dict] = {}
 
-        result = to_embed(tweet, users_idx, media_idx)
+        result = get_tweet_url(tweet, users_idx)
+        expected = "https://x.com/unknown/status/123456789"
 
-        assert result["title"] == "@unknown"
-        assert result["author"]["name"] == "unknown"
-        assert result["url"] == "https://x.com/unknown/status/123456789"
-
-    def test_to_embed_long_text(self):
-        """長いテキストのツイート埋め込み変換テスト"""
-        long_text = "A" * 5000  # 4000文字を超える長いテキスト
-
-        tweet = {
-            "id": "123456789",
-            "author_id": "user1",
-            "text": long_text,
-            "public_metrics": {
-                "like_count": 1,
-                "retweet_count": 0,
-            },
-        }
-
-        users_idx = {
-            "user1": {
-                "username": "testuser",
-                "name": "Test User",
-            }
-        }
-
-        media_idx: dict[str, dict] = {}
-
-        result = to_embed(tweet, users_idx, media_idx)
-
-        # テキストが4000文字以下に制限されることを確認
-        assert len(result["description"]) <= 4000
-
-    def test_to_embed_html_entities(self):
-        """HTMLエンティティを含むツイートの埋め込み変換テスト"""
-        tweet = {
-            "id": "123456789",
-            "author_id": "user1",
-            "text": "Test &amp; tweet with &lt;html&gt; entities",
-            "public_metrics": {
-                "like_count": 5,
-                "retweet_count": 2,
-            },
-        }
-
-        users_idx = {
-            "user1": {
-                "username": "testuser",
-                "name": "Test User",
-            }
-        }
-
-        media_idx: dict[str, dict] = {}
-
-        result = to_embed(tweet, users_idx, media_idx)
-
-        # HTMLエンティティがデコードされることを確認
-        assert result["description"] == "Test & tweet with <html> entities"
+        assert result == expected


### PR DESCRIPTION
## 概要

ツイートの詳細情報を含むリッチな埋め込みの代わりに、シンプルなツイートURLをDiscordに送信するように変更しました。

## 変更内容

### 主な変更
- 関数を削除し、関数に置き換え
- Discord投稿でリッチ埋め込みの代わりにプレーンなURLを送信
- メディア情報のインデックス化ロジックを削除（不要になったため）
- モジュールの依存関係を削除

### ファイル変更
- : 複雑な埋め込み生成を削除、シンプルなURL生成に変更
- : 新しいURL送信ロジックに対応
- : エクスポート関数を更新
- : 新しい動作に合わせてテストを更新

## 利点

1. **シンプルな実装**: 複雑な埋め込み生成ロジックが不要
2. **Discordネイティブ対応**: DiscordのツイートプレビューAPIを活用
3. **保守性向上**: コードが大幅に簡素化
4. **信頼性向上**: Discord側の標準的なプレビュー機能を使用

## テスト

- すべての既存テストが正常に通ることを確認
- 新しい関数の単体テストを追加
- リンターエラーなし

## 動作確認

- URL形式: 
- Discordが自動的にツイート内容をプレビュー表示